### PR TITLE
Set sidebar open to default

### DIFF
--- a/src/components/channels/index.tsx
+++ b/src/components/channels/index.tsx
@@ -99,7 +99,7 @@ const ChannelsSideBar = ({ children }) => {
     (state: any) => state.clickActions.channelsSideBar
   );
   const theme = useTheme();
-  const [open, setOpen] = React.useState(false);
+  const [open, setOpen] = React.useState(true);
 
   React.useEffect(() => {
     if (toggle) {


### PR DESCRIPTION
The sidebar left is opened by default

![image](https://github.com/hannahNchan/slackclone/assets/58449528/d1f1cfe9-5780-456f-a430-3582ca1d67a6)
